### PR TITLE
ci: Use a more restrictive token for GitHub Releases in the workflow

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -124,7 +124,7 @@ jobs:
         uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
         if: ${{ github.ref == 'refs/heads/root' && env.VERSION != env.PREVIOUS_COMMIT_VERSION }}
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          repo_token: "${{ secrets.RELEASES_TOKEN }}"
           automatic_release_tag: v${{ env.VERSION }}
           prerelease: false
           files: |


### PR DESCRIPTION
This token, stored in the `RELEASES_TOKEN`
secret, has permissions restricted to
reading and writing contents for the
`jjversion-gha-output` repository.

This strengthens security and also addresses the following error:

```
Generating release tag
  Attempting to create or update release tag "v0.2.9"
  ##[debug] request {"method":"POST","baseUrl":"https://api.github.com/","headers":{"accept":"application/vnd.github.v3+json","user-agent":"octokit.js/16.33.0 Node.js/12.22.7 (Linux 5.15; x64)","authorization":"token ***"},"mediaType":{"format":"","previews":[]},"request":{"validate":{"owner":{"required":true,"type":"string"},"ref":{"required":true,"type":"string"},"repo":{"required":true,"type":"string"},"sha":{"required":true,"type":"string"}}},"url":"/repos/:owner/:repo/git/refs","owner":"jjliggett","ref":"refs/tags/v0.2.9","repo":"jjversion-gha-output","sha":"9b96f7b7430fa2faa84ccc0d95e471fcb1409b49"}
  ##[debug] POST /repos/jjliggett/jjversion-gha-output/git/refs - 403 in 170ms
  Could not create new tag "refs/tags/v0.2.9" (Resource not accessible by integration) therefore updating existing tag "tags/v0.2.9"
  ##[debug] request {"method":"PATCH","baseUrl":"https://api.github.com/","headers":{"accept":"application/vnd.github.v3+json","user-agent":"octokit.js/16.33.0 Node.js/12.22.7 (Linux 5.15; x64)","authorization":"token ***"},"mediaType":{"format":"","previews":[]},"request":{"validate":{"force":{"type":"boolean"},"owner":{"required":true,"type":"string"},"ref":{"required":true,"type":"string"},"repo":{"required":true,"type":"string"},"sha":{"required":true,"type":"string"}}},"url":"/repos/:owner/:repo/git/refs/:ref","owner":"jjliggett","ref":"tags/v0.2.9","repo":"jjversion-gha-output","sha":"9b96f7b7430fa2faa84ccc0d95e471fcb1409b49","force":true}
  ##[debug] PATCH /repos/jjliggett/jjversion-gha-output/git/refs/tags/v0.2.9 - 403 in 144ms
  Error: Resource not accessible by integration
  (node:10734) UnhandledPromiseRejectionWarning: HttpError: Resource not accessible by integration
      at /home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:361876
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
  (node:10734) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
  (node:10734) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
  ##[debug]Node Action run completed with exit code 1
  ##[debug]Finishing: Create GitHub release
```

( https://github.com/jjliggett/jjversion-gha-output/actions/runs/3357358535/jobs/5563338144 )