### PR TITLE
ci: Refine workflow trigger conditions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,5 +1,23 @@
 name: actions
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - README.md
+      - LICENSE.md
+      - ATTRIBUTIONS.md
+      - '.github/workflows/codeql-analysis.yaml'
+      - '.github/dependabot.yaml'
+    branches:
+      - root
+  pull_request:
+    paths-ignore:
+      - README.md
+      - LICENSE.md
+      - ATTRIBUTIONS.md
+      - '.github/workflows/codeql-analysis.yaml'
+      - '.github/dependabot.yaml'
+    workflow_dispatch:
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
This change prevents duplicate pull request workflow executions.

Previously, each workflow job would run twice for pull requests (as shown in https://github.com/jjliggett/jjversion-gha-output/pull/30 ):

![image](https://user-images.githubusercontent.com/67353173/198916774-2aecafc4-ed3a-4c4b-a82c-1241bc5aef0b.png)

The `workflow_dispatch` trigger was added so that testing on a branch can be performed without opening a pull request.

This is similar to https://github.com/jjliggett/jjversion/pull/140 and https://github.com/jjliggett/CurrentTimeApp/pull/50