### PR TITLE
feat: Migrate from set-output command

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
 
 	jjvercore "github.com/jjliggett/jjversion/jjvercore"
 )
@@ -13,11 +16,39 @@ func main() {
 	println(v.Json())
 	println("::endgroup::")
 
-	fmt.Printf("::set-output name=major::%d\n", v.Major)
-	fmt.Printf("::set-output name=minor::%d\n", v.Minor)
-	fmt.Printf("::set-output name=patch::%d\n", v.Patch)
-	fmt.Printf("::set-output name=majorMinorPatch::%d.%d.%d\n", v.Major, v.Minor, v.Patch)
-	fmt.Printf("::set-output name=sha::%s\n", v.Sha)
-	fmt.Printf("::set-output name=shortSha::%s\n", v.Sha[:7])
+	println("::group::$GITHUB_OUTPUT environment value")
+	output := os.Getenv("GITHUB_OUTPUT")
+	println(output)
+	println("::endgroup::")
+
+	file, err := os.OpenFile(output, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	content := fmt.Sprintf("major=%d\n"+
+		"minor=%d\n"+
+		"patch=%d\n"+
+		"majorMinorPatch=%d.%d.%d\n"+
+		"sha=%s\n"+
+		"shortSha=%s\n",
+		v.Major, v.Minor, v.Patch, v.Major, v.Minor, v.Patch, v.Sha, v.Sha[:7])
+
+	defer file.Close()
+
+	_, err = file.WriteString(content)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	result, err := ioutil.ReadFile(output)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	println("::group::$GITHUB_OUTPUT value")
+	text := string(result)
+	println(text)
+	println("::endgroup::")
 
 }


### PR DESCRIPTION
The `set-output` GitHub workflow command to save outputs for use within other steps has been deprecated.

The functionality is now provided through a `GITHUB_OUTPUT` environment file which lets you write output variables, similar to the old `set-output` command.

This change updates the jjversion-gha-output application to use this new method for output variables.

The application gets the name of the file using the `GITHUB_OUTPUT` environment variable and then the application appends the values to that file.

Details about the deprecation can be found here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/