### PR TITLE
fix: Update workflow syntax to fix GitHub release logic

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -142,7 +142,7 @@ jobs:
         uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
         if: ${{ github.ref == 'refs/heads/root' && env.VERSION != env.PREVIOUS_COMMIT_VERSION }}
         with:
-          repo_token: "${{ secrets.RELEASES_TOKEN }}"
+          repo_token: ${{ secrets.RELEASES_TOKEN }}
           automatic_release_tag: v${{ env.VERSION }}
           prerelease: false
           files: |


### PR DESCRIPTION
This addresses the following error in the GitHub workflow:

```
Run marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
Error: Input required and not supplied: repo_token
(node:10778) UnhandledPromiseRejectionWarning: Error: Input required and not supplied: repo_token
    at Object.f [as getInput] (/home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:12178)
    at /home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:214236
    at /home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:214597
    at Generator.next (<anonymous>)
    at /home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:212886
    at new Promise (<anonymous>)
    at s (/home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:212631)
    at Object.t.main (/home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:214[16](https://github.com/jjliggett/jjversion-gha-output/actions/runs/3453868671/jobs/5764795471#step:29:17)1)
    at Object.<anonymous> (/home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b[17](https://github.com/jjliggett/jjversion-gha-output/actions/runs/3453868671/jobs/5764795471#step:29:18)9569b7a6fb4d8860689ab7f0/dist/index.js:1:212004)
    at r (/home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:124)
(node:10778) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:10778) [DEP00[18](https://github.com/jjliggett/jjversion-gha-output/actions/runs/3453868671/jobs/5764795471#step:29:19)] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

( https://github.com/jjliggett/jjversion-gha-output/actions/runs/3453868671/jobs/5764795471 )

This is similar to the syntax change for a similar error here: https://github.com/jjliggett/CurrentTimeApp/pull/75

This will be tested upon merging the pull request.