### PR TITLE
ci: Add devcontainers to dependabot.yaml & add devcontainer-lock.json

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2.4.1": {
+      "version": "2.4.1",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:02045d6381c5d57e3c4e0e499046724bc9c3142c97b17432456c74a82e221b97",
+      "integrity": "sha256:02045d6381c5d57e3c4e0e499046724bc9c3142c97b17432456c74a82e221b97"
+    },
+    "ghcr.io/devcontainers/features/go:1.2.2": {
+      "version": "1.2.2",
+      "resolved": "ghcr.io/devcontainers/features/go@sha256:d5e34970f31942a4d9f6b3f6f52da1176b2dcb35aeba3f0fc93b974e287d3b16",
+      "integrity": "sha256:d5e34970f31942a4d9f6b3f6f52da1176b2dcb35aeba3f0fc93b974e287d3b16"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,8 @@
         "dockerfile": "Dockerfile"
     },
 	"features": {
-        "ghcr.io/devcontainers/features/common-utils:2.1.0": {},
-		"ghcr.io/devcontainers/features/go:1.2.0": {
+        "ghcr.io/devcontainers/features/common-utils:2.4.1": {},
+		"ghcr.io/devcontainers/features/go:1.2.2": {
 			"version": "1.21.0"
 		}
 	},

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -25,3 +25,16 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    assignees:
+      - "jjliggett"
+    reviewers:
+      - "jjliggett"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
This is similar to:

- https://github.com/jjliggett/jjversion/pull/316

For context, see: [github.blog/changelog/2024-01-24-dependabot-version-updates-support-devcontainers](https://github.blog/changelog/2024-01-24-dependabot-version-updates-support-devcontainers/)