### PR TITLE
ci: replace releases action

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -118,12 +118,15 @@ jobs:
           name: jjversion-ghao-docs-and-licenses-${{ env.VERSION }}.zip
           path: jjversion-ghao-docs-and-licenses-${{ env.VERSION }}.zip
       - name: Create GitHub release
-        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
+        uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564 # v2.0.4
         if: ${{ github.ref == 'refs/heads/root' && env.VERSION != env.PREVIOUS_COMMIT_VERSION }}
         with:
-          repo_token: ${{ secrets.RELEASES_TOKEN }}
-          automatic_release_tag: v${{ env.VERSION }}
+          token: ${{ secrets.RELEASES_TOKEN }}
+          tag_name: v${{ env.VERSION }}
+          draft: false
           prerelease: false
+          generate_release_notes: true
+          make_latest: true
           files: |
             jjversion-ghao-${{ env.VERSION }}-linux-x64/jjversion-ghao
             jjversion-ghao-${{ env.VERSION }}-darwin-amd64/jjversion-ghao-darwin


### PR DESCRIPTION
The motivation behind this change was that the original action for releases has not been maintained for some time - see

- https://github.com/marvinpinto/action-automatic-releases/pull/2

The workflow now uses https://github.com/softprops/action-gh-release

This is similar to:

- https://github.com/jjliggett/jjversion/pull/350