### PR TITLE
fix(ci): use secrets.GITHUB_TOKEN for release

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -20,6 +20,9 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   test:
     strategy:
@@ -121,7 +124,7 @@ jobs:
         uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564 # v2.0.4
         if: ${{ github.ref == 'refs/heads/root' && env.VERSION != env.PREVIOUS_COMMIT_VERSION }}
         with:
-          token: ${{ secrets.RELEASES_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN  }}
           tag_name: v${{ env.VERSION }}
           draft: false
           prerelease: false


### PR DESCRIPTION
This is an attempt to resolve the following issue:

![image](https://github.com/jjliggett/jjversion-gha-output/assets/67353173/88de761e-a971-4a41-9d69-c3403f85cbff)

```
##[debug]Evaluating condition for step: 'Create GitHub release'
##[debug]Evaluating: (success() && (github.ref == 'refs/heads/root') && (env.VERSION != env.PREVIOUS_COMMIT_VERSION))
##[debug]Evaluating And:
##[debug]..Evaluating success:
##[debug]..=> true
##[debug]..Evaluating Equal:
##[debug]....Evaluating Index:
##[debug]......Evaluating github:
##[debug]......=> Object
##[debug]......Evaluating String:
##[debug]......=> 'ref'
##[debug]....=> 'refs/heads/root'
##[debug]....Evaluating String:
##[debug]....=> 'refs/heads/root'
##[debug]..=> true
##[debug]..Evaluating NotEqual:
##[debug]....Evaluating Index:
##[debug]......Evaluating env:
##[debug]......=> Object
##[debug]......Evaluating String:
##[debug]......=> 'VERSION'
##[debug]....=> '0.3.44'
##[debug]....Evaluating Index:
##[debug]......Evaluating env:
##[debug]......=> Object
##[debug]......Evaluating String:
##[debug]......=> 'PREVIOUS_COMMIT_VERSION'
##[debug]....=> '0.3.43'
##[debug]..=> true
##[debug]=> true
##[debug]Expanded: (true && ('refs/heads/root' == 'refs/heads/root') && ('0.3.44' != '0.3.43'))
##[debug]Result: true
##[debug]Starting: Create GitHub release
##[debug]Loading inputs
##[debug]Evaluating: secrets.RELEASES_TOKEN
##[debug]Evaluating Index:
##[debug]..Evaluating secrets:
##[debug]..=> Object
##[debug]..Evaluating String:
##[debug]..=> 'RELEASES_TOKEN'
##[debug]=> '***'
##[debug]Result: '***'
##[debug]Evaluating: format('v{0}', env.VERSION)
##[debug]Evaluating format:
##[debug]..Evaluating String:
##[debug]..=> 'v{0}'
##[debug]..Evaluating Index:
##[debug]....Evaluating env:
##[debug]....=> Object
##[debug]....Evaluating String:
##[debug]....=> 'VERSION'
##[debug]..=> '0.3.44'
##[debug]=> 'v0.3.44'
##[debug]Result: 'v0.3.44'
##[debug]Evaluating: format('jjversion-ghao-{0}-linux-x64/jjversion-ghao
##[debug]jjversion-ghao-{1}-darwin-amd64/jjversion-ghao-darwin
##[debug]jjversion-ghao-{2}-windows-x64/jjversion-ghao.exe
##[debug]README.md
##[debug]LICENSE.md
##[debug]jjversion-ghao-docs-and-licenses-{3}.zip
##[debug]', env.VERSION, env.VERSION, env.VERSION, env.VERSION)
##[debug]Evaluating format:
##[debug]..Evaluating String:
##[debug]..=> 'jjversion-ghao-{0}-linux-x64/jjversion-ghao
##[debug]jjversion-ghao-{1}-darwin-amd64/jjversion-ghao-darwin
##[debug]jjversion-ghao-{2}-windows-x64/jjversion-ghao.exe
##[debug]README.md
##[debug]LICENSE.md
##[debug]jjversion-ghao-docs-and-licenses-{3}.zip
##[debug]'
##[debug]..Evaluating Index:
##[debug]....Evaluating env:
##[debug]....=> Object
##[debug]....Evaluating String:
##[debug]....=> 'VERSION'
##[debug]..=> '0.3.44'
##[debug]..Evaluating Index:
##[debug]....Evaluating env:
##[debug]....=> Object
##[debug]....Evaluating String:
##[debug]....=> 'VERSION'
##[debug]..=> '0.3.44'
##[debug]..Evaluating Index:
##[debug]....Evaluating env:
##[debug]....=> Object
##[debug]....Evaluating String:
##[debug]....=> 'VERSION'
##[debug]..=> '0.3.44'
##[debug]..Evaluating Index:
##[debug]....Evaluating env:
##[debug]....=> Object
##[debug]....Evaluating String:
##[debug]....=> 'VERSION'
##[debug]..=> '0.3.44'
##[debug]=> 'jjversion-ghao-0.3.44-linux-x64/jjversion-ghao
##[debug]jjversion-ghao-0.3.44-darwin-amd64/jjversion-ghao-darwin
##[debug]jjversion-ghao-0.3.44-windows-x64/jjversion-ghao.exe
##[debug]README.md
##[debug]LICENSE.md
##[debug]jjversion-ghao-docs-and-licenses-0.3.44.zip
##[debug]'
##[debug]Result: 'jjversion-ghao-0.3.44-linux-x64/jjversion-ghao
##[debug]jjversion-ghao-0.3.44-darwin-amd64/jjversion-ghao-darwin
##[debug]jjversion-ghao-0.3.44-windows-x64/jjversion-ghao.exe
##[debug]README.md
##[debug]LICENSE.md
##[debug]jjversion-ghao-docs-and-licenses-0.3.44.zip
##[debug]'
##[debug]Loading env
Run softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
⚠️ Unexpected error fetching GitHub release for tag refs/heads/root: HttpError: Bad credentials
Error: Bad credentials
##[debug]Node Action run completed with exit code 1
##[debug]Finishing: Create GitHub release
```

This relates to:

- https://github.com/jjliggett/jjversion-gha-output/pull/120